### PR TITLE
Update v3.28.0

### DIFF
--- a/org.gnome.Gnote.json
+++ b/org.gnome.Gnote.json
@@ -1,7 +1,7 @@
 {
     "app-id": "org.gnome.Gnote",
     "runtime": "org.gnome.Platform",
-    "runtime-version": "3.26",
+    "runtime-version": "3.28",
     "sdk": "org.gnome.Sdk",
     "command": "gnote",
     "rename-appdata-file": "gnote.appdata.xml",
@@ -29,8 +29,8 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "http://ftp.gnome.org/pub/GNOME/sources/libsigc++/2.10/libsigc++-2.10.0.tar.xz",
-                    "sha256": "f843d6346260bfcb4426259e314512b99e296e8ca241d771d21ac64f28298d81"
+                    "url": "https://ftp.gnome.org/pub/GNOME/sources/libsigc++/2.99/libsigc++-2.99.10.tar.xz",
+                    "sha256": "68cdb00e39d6b913d22b0ac362312447c8b4014146b8efd2a9299d9916c72260"
                 }
             ]
         },
@@ -39,8 +39,8 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "http://ftp.gnome.org/pub/GNOME/sources/glibmm/2.54/glibmm-2.54.1.tar.xz",
-                    "sha256": "7cc28c732b04d70ed34f0c923543129083cfb90580ea4a2b4be5b38802bf6a4a"
+                    "url": "https://ftp.gnome.org/pub/GNOME/sources/glibmm/2.55/glibmm-2.55.2.tar.xz",
+                    "sha256": "958735bebc2efc68276e191d064e5ebf590ec11d14783a0aa52a5cd796d0f34a"
                 }
             ]
         },
@@ -49,8 +49,8 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "http://ftp.gnome.org/pub/GNOME/sources/cairomm/1.12/cairomm-1.12.0.tar.xz",
-                    "sha256": "a54ada8394a86182525c0762e6f50db6b9212a2109280d13ec6a0b29bfd1afe6"
+                    "url": "https://ftp.gnome.org/pub/GNOME/sources/cairomm/1.15/cairomm-1.15.4.tar.xz",
+                    "sha256": "4cd9fd959538953dfa606aaa7a31381e3193eebf14d814d97ef928684ee9feb5"
                 }
             ]
         },
@@ -59,8 +59,8 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "http://ftp.gnome.org/pub/GNOME/sources/pangomm/2.40/pangomm-2.40.1.tar.xz",
-                    "sha256": "9762ee2a2d5781be6797448d4dd2383ce14907159b30bc12bf6b08e7227be3af"
+                    "url": "https://ftp.gnome.org/pub/GNOME/sources/pangomm/2.41/pangomm-2.41.5.tar.xz",
+                    "sha256": "5131830d5b37b181ca4fa8f641ad86faa985c0bb7dcc833c98672d294367b304"
                 }
             ]
         },
@@ -69,8 +69,8 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "http://ftp.gnome.org/pub/GNOME/sources/atkmm/2.24/atkmm-2.24.2.tar.xz",
-                    "sha256": "ff95385759e2af23828d4056356f25376cfabc41e690ac1df055371537e458bd"
+                    "url": "https://ftp.gnome.org/pub/GNOME/sources/atkmm/2.27/atkmm-2.27.1.tar.xz",
+                    "sha256": "cf40bca4ae917bdc2a335cd8c9a9ad84859d8cfb4f8e3dd7741676948e28338c"
                 }
             ]
         },
@@ -79,8 +79,8 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "http://ftp.gnome.org/pub/GNOME/sources/gtkmm/3.22/gtkmm-3.22.2.tar.xz",
-                    "sha256": "91afd98a31519536f5f397c2d79696e3d53143b80b75778521ca7b48cb280090"
+                    "url": "https://ftp.gnome.org/pub/GNOME/sources/gtkmm/3.93/gtkmm-3.93.0.tar.xz",
+                    "sha256": "52d3e8327ac420cfa0aaedff177f755684952b5606496caee1330409f2ede8e5"
                 }
             ]
         },
@@ -89,8 +89,8 @@
             "sources": [
                 {
                 "type": "archive",
-                "url": "https://download.gnome.org/sources/gnote/3.26/gnote-3.26.0.tar.xz",
-                "sha256": "de205ace226a010aba576654db6a8e06eab064522549d3bdd6eb8a0bc9163be9"
+                "url": "https://download.gnome.org/sources/gnote/3.28/gnote-3.28.0.tar.xz",
+                "sha256": "a50d3986c6cc04c7c8215dfed938910611e2d7499f00bfe4f42050ed56a7b783"
                 }
             ],
             "post-install": [


### PR DESCRIPTION
3.28.0 - 2018/03/18

New Features:
  * Client side decoration by default supported on Ubuntu and Pop! sessions
  * Install appdata metadata to new non-deprecated location (#792795)

Fixes:
  * Manual validation fixes
  * Fix gettext-domain in GSettings schema
  * Do not show empty actions menu (#789750)
  * Fix some shortcuts, that are added by context menu (#792859)

Translations:
  * Updated translations:
    - Brazilian Portuguese (pt_BR)
    - Czech (cs)
    - Danish (da)
    - German (de)
    - Hungarian (hu)
    - Indonesian (id)
    - Lithuanian (lt)
    - Polish (pl)
    - Serbian (sr, sr@latin)
    - Spanish (es)
    - Swedish (sv)
  * Updated Slovenian manual (sl)
  * Updated Spanish manual (es)