### PR TITLE
Remove redundant build flags

### DIFF
--- a/org.gnome.Gnote.json
+++ b/org.gnome.Gnote.json
@@ -14,10 +14,6 @@
         "--filesystem=xdg-run/dconf", "--filesystem=~/.config/dconf:ro",
         "--talk-name=ca.desrt.dconf", "--env=DCONF_USER_CONFIG_DIR=.config/dconf"
     ],
-    "build-options" : {
-        "cflags": "-O2 -g",
-        "cxxflags": "-O2 -g"
-    },
     "cleanup": [
         "*.a",
         "*.la",


### PR DESCRIPTION
The 3.30 runtime sets these as defaults.