### PR TITLE
Update to GNOME runtime 3.32 and Gnote 3.32.1

### DIFF
--- a/Add-OARS-and-update-appdata.patch
+++ b/Add-OARS-and-update-appdata.patch
@@ -1,0 +1,65 @@
+From 2a13aad9ed35a7a8f546c6b85879eaf40b90cd68 Mon Sep 17 00:00:00 2001
+From: nick richards <nick.richards@gmail.com>
+Date: Tue, 5 Jun 2018 13:31:23 +0000
+Subject: [PATCH 1/6] Add OARS and update appdata
+
+---
+ data/appdata/gnote.appdata.xml.in | 35 ++++++++++++++++++++++++++++++-
+ 1 file changed, 34 insertions(+), 1 deletion(-)
+
+diff --git a/data/appdata/gnote.appdata.xml.in b/data/appdata/gnote.appdata.xml.in
+index ac3d87f7..34b737ff 100644
+--- a/data/appdata/gnote.appdata.xml.in
++++ b/data/appdata/gnote.appdata.xml.in
+@@ -2,7 +2,8 @@
+ <!-- Copyright 2013 Aurimas Cernius <aurisc4@gmail.com> -->
+ <application>
+  <id type="desktop">gnote.desktop</id>
+- <licence>CC0</licence>
++ <metadata_licence>CC0-1.0</metadata_licence>
++ <project_license>GPL-3.0-only and GFDL-1.1-only</project_license>
+  <_name>Gnote</_name>
+  <_summary>A simple note-taking application</_summary>
+  <description>
+@@ -15,6 +16,38 @@
+   <screenshot type="default" width="624" height="351">https://wiki.gnome.org/Apps/Gnote?action=AttachFile&amp;do=get&amp;target=gnote_main_window.png</screenshot>
+  </screenshots>
+  <url type="homepage">https://wiki.gnome.org/Gnote</url>
++ <url type="bugtracker">https://gitlab.gnome.org/GNOME/gnote/issues</url>
++ <url type="donation">http://www.gnome.org/friends/</url>
++ <url type="translate">https://wiki.gnome.org/TranslationProject</url>
+  <updatecontact>aurisc4_at_gmail.com</updatecontact>
++ <content_rating type="oars-1.1">
++    <content_attribute id="violence-cartoon">none</content_attribute>
++    <content_attribute id="violence-fantasy">none</content_attribute>
++    <content_attribute id="violence-realistic">none</content_attribute>
++    <content_attribute id="violence-bloodshed">none</content_attribute>
++    <content_attribute id="violence-sexual">none</content_attribute>
++    <content_attribute id="violence-desecration">none</content_attribute>
++    <content_attribute id="violence-slavery">none</content_attribute>
++    <content_attribute id="violence-worship">none</content_attribute>
++    <content_attribute id="drugs-alcohol">none</content_attribute>
++    <content_attribute id="drugs-narcotics">none</content_attribute>
++    <content_attribute id="drugs-tobacco">none</content_attribute>
++    <content_attribute id="sex-nudity">none</content_attribute>
++    <content_attribute id="sex-themes">none</content_attribute>
++    <content_attribute id="sex-homosexuality">none</content_attribute>
++    <content_attribute id="sex-prostitution">none</content_attribute>
++    <content_attribute id="sex-adultery">none</content_attribute>
++    <content_attribute id="sex-appearance">none</content_attribute>
++    <content_attribute id="language-profanity">none</content_attribute>
++    <content_attribute id="language-humor">none</content_attribute>
++    <content_attribute id="language-discrimination">none</content_attribute>
++    <content_attribute id="social-chat">none</content_attribute>
++    <content_attribute id="social-info">none</content_attribute>
++    <content_attribute id="social-audio">none</content_attribute>
++    <content_attribute id="social-location">none</content_attribute>
++    <content_attribute id="social-contacts">none</content_attribute>
++    <content_attribute id="money-purchasing">none</content_attribute>
++    <content_attribute id="money-gambling">none</content_attribute>
++ </content_rating>
+ </application>
+ 
+-- 
+2.20.1
+

--- a/appdata-add-release-for-3.32.0.patch
+++ b/appdata-add-release-for-3.32.0.patch
@@ -1,0 +1,25 @@
+From 5f3390a61e608cf490901147014e37bfb0a85889 Mon Sep 17 00:00:00 2001
+From: Will Thompson <will@willthompson.co.uk>
+Date: Mon, 15 Jul 2019 15:55:28 +0100
+Subject: [PATCH 4/6] appdata: add <release> for 3.32.0
+
+---
+ data/appdata/gnote.appdata.xml.in | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/data/appdata/gnote.appdata.xml.in b/data/appdata/gnote.appdata.xml.in
+index 851a5926..47edb72e 100644
+--- a/data/appdata/gnote.appdata.xml.in
++++ b/data/appdata/gnote.appdata.xml.in
+@@ -21,5 +21,8 @@
+  <url type="translate">https://wiki.gnome.org/TranslationProject</url>
+  <update_contact>aurisc4_at_gmail.com</update_contact>
+  <content_rating type="oars-1.1"/>
++ <releases>
++  <release version="3.32.0" date="2019-03-17"/>
++ </releases>
+ </application>
+ 
+-- 
+2.20.1
+

--- a/appdata-add-release-for-3.32.1.patch
+++ b/appdata-add-release-for-3.32.1.patch
@@ -1,0 +1,24 @@
+From 53a2140a2ff81e0c963b2bee92f26ce0848afa12 Mon Sep 17 00:00:00 2001
+From: Will Thompson <will@willthompson.co.uk>
+Date: Mon, 15 Jul 2019 15:57:05 +0100
+Subject: [PATCH 6/6] appdata: add <release> for 3.32.1
+
+---
+ data/appdata/gnote.appdata.xml.in | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/data/appdata/gnote.appdata.xml.in b/data/appdata/gnote.appdata.xml.in
+index 662740b2..0d443a14 100644
+--- a/data/appdata/gnote.appdata.xml.in
++++ b/data/appdata/gnote.appdata.xml.in
+@@ -22,6 +22,7 @@
+  <update_contact>aurisc4_at_gmail.com</update_contact>
+  <content_rating type="oars-1.1"/>
+  <releases>
++  <release version="3.32.1" date="2019-04-14"/>
+   <release version="3.32.0" date="2019-03-17"/>
+  </releases>
+  <translation type="gettext">gnote</translation>
+-- 
+2.20.1
+

--- a/appdata-replace-updatecontact-with-update_contact.patch
+++ b/appdata-replace-updatecontact-with-update_contact.patch
@@ -1,0 +1,34 @@
+From 996ac307416c42755bbe04a5b5ffd50c0e603bd5 Mon Sep 17 00:00:00 2001
+From: Will Thompson <will@willthompson.co.uk>
+Date: Mon, 15 Jul 2019 15:53:01 +0100
+Subject: [PATCH 2/6] appdata: replace <updatecontact> with <update_contact>
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+appstream-util validate-strict reports:
+
+• tag-invalid           : <updatecontact> should be <update_contact>
+
+https://www.freedesktop.org/software/appstream/docs/chap-Quickstart.html
+agrees that the latter is the correct tag name.
+---
+ data/appdata/gnote.appdata.xml.in | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/data/appdata/gnote.appdata.xml.in b/data/appdata/gnote.appdata.xml.in
+index 34b737ff..e3d49da6 100644
+--- a/data/appdata/gnote.appdata.xml.in
++++ b/data/appdata/gnote.appdata.xml.in
+@@ -19,7 +19,7 @@
+  <url type="bugtracker">https://gitlab.gnome.org/GNOME/gnote/issues</url>
+  <url type="donation">http://www.gnome.org/friends/</url>
+  <url type="translate">https://wiki.gnome.org/TranslationProject</url>
+- <updatecontact>aurisc4_at_gmail.com</updatecontact>
++ <update_contact>aurisc4_at_gmail.com</update_contact>
+  <content_rating type="oars-1.1">
+     <content_attribute id="violence-cartoon">none</content_attribute>
+     <content_attribute id="violence-fantasy">none</content_attribute>
+-- 
+2.20.1
+

--- a/appdata-simplify-content_rating.patch
+++ b/appdata-simplify-content_rating.patch
@@ -1,0 +1,56 @@
+From 5f25de59673621c4270cc2158a7a5a6de9aa8b5f Mon Sep 17 00:00:00 2001
+From: Will Thompson <will@willthompson.co.uk>
+Date: Mon, 15 Jul 2019 21:11:01 +0100
+Subject: [PATCH 3/6] appdata: simplify <content_rating>
+
+The default level for each category is 'none'.
+
+Spotted by Patrick Griffis over at
+<https://github.com/flathub/org.gnome.Gnote/pull/8#discussion_r303571194>.
+---
+ data/appdata/gnote.appdata.xml.in | 30 +-----------------------------
+ 1 file changed, 1 insertion(+), 29 deletions(-)
+
+diff --git a/data/appdata/gnote.appdata.xml.in b/data/appdata/gnote.appdata.xml.in
+index e3d49da6..851a5926 100644
+--- a/data/appdata/gnote.appdata.xml.in
++++ b/data/appdata/gnote.appdata.xml.in
+@@ -20,34 +20,6 @@
+  <url type="donation">http://www.gnome.org/friends/</url>
+  <url type="translate">https://wiki.gnome.org/TranslationProject</url>
+  <update_contact>aurisc4_at_gmail.com</update_contact>
+- <content_rating type="oars-1.1">
+-    <content_attribute id="violence-cartoon">none</content_attribute>
+-    <content_attribute id="violence-fantasy">none</content_attribute>
+-    <content_attribute id="violence-realistic">none</content_attribute>
+-    <content_attribute id="violence-bloodshed">none</content_attribute>
+-    <content_attribute id="violence-sexual">none</content_attribute>
+-    <content_attribute id="violence-desecration">none</content_attribute>
+-    <content_attribute id="violence-slavery">none</content_attribute>
+-    <content_attribute id="violence-worship">none</content_attribute>
+-    <content_attribute id="drugs-alcohol">none</content_attribute>
+-    <content_attribute id="drugs-narcotics">none</content_attribute>
+-    <content_attribute id="drugs-tobacco">none</content_attribute>
+-    <content_attribute id="sex-nudity">none</content_attribute>
+-    <content_attribute id="sex-themes">none</content_attribute>
+-    <content_attribute id="sex-homosexuality">none</content_attribute>
+-    <content_attribute id="sex-prostitution">none</content_attribute>
+-    <content_attribute id="sex-adultery">none</content_attribute>
+-    <content_attribute id="sex-appearance">none</content_attribute>
+-    <content_attribute id="language-profanity">none</content_attribute>
+-    <content_attribute id="language-humor">none</content_attribute>
+-    <content_attribute id="language-discrimination">none</content_attribute>
+-    <content_attribute id="social-chat">none</content_attribute>
+-    <content_attribute id="social-info">none</content_attribute>
+-    <content_attribute id="social-audio">none</content_attribute>
+-    <content_attribute id="social-location">none</content_attribute>
+-    <content_attribute id="social-contacts">none</content_attribute>
+-    <content_attribute id="money-purchasing">none</content_attribute>
+-    <content_attribute id="money-gambling">none</content_attribute>
+- </content_rating>
++ <content_rating type="oars-1.1"/>
+ </application>
+ 
+-- 
+2.20.1
+

--- a/appdata-specify-translation.patch
+++ b/appdata-specify-translation.patch
@@ -1,0 +1,25 @@
+From 06355fe2e15e5482df6e7a4b853596e3426a9918 Mon Sep 17 00:00:00 2001
+From: Will Thompson <will@willthompson.co.uk>
+Date: Mon, 15 Jul 2019 16:22:18 +0100
+Subject: [PATCH 5/6] appdata: specify <translation>
+
+This allows the generated appstream to include data on the app's
+translation coverage.
+---
+ data/appdata/gnote.appdata.xml.in | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/data/appdata/gnote.appdata.xml.in b/data/appdata/gnote.appdata.xml.in
+index 47edb72e..662740b2 100644
+--- a/data/appdata/gnote.appdata.xml.in
++++ b/data/appdata/gnote.appdata.xml.in
+@@ -24,5 +24,6 @@
+  <releases>
+   <release version="3.32.0" date="2019-03-17"/>
+  </releases>
++ <translation type="gettext">gnote</translation>
+ </application>
+ 
+-- 
+2.20.1
+

--- a/gtkmm.yaml
+++ b/gtkmm.yaml
@@ -1,0 +1,87 @@
+name: gtkmm
+sources:
+  - sha256: ddfe42ed2458a20a34de252854bcf4b52d3f0c671c045f56b42aa27c7542d2fd
+    type: archive
+    url: http://ftp.gnome.org/pub/GNOME/sources/gtkmm/3.24/gtkmm-3.24.1.tar.xz
+config-opts:
+  - --disable-documentation
+cleanup:
+  - '*.a'
+  - '*.la'
+  - /include
+  - /lib/gdkmm-3.0
+  - /lib/gtkmm-3.0
+  - /lib/pkgconfig
+  - /man
+  - /share/aclocal
+  - /share/man
+  - /share/pkgconfig
+
+modules:
+  - name: sigc++
+    sources:
+      - sha256: c9a25f26178c6cbb147f9904d8c533b5a5c5111a41ac2eb781eb734eea446003
+        type: archive
+        url: http://ftp.gnome.org/pub/GNOME/sources/libsigc++/2.10/libsigc++-2.10.1.tar.xz
+    config-opts:
+      - --disable-documentation
+    cleanup:
+      - '*.la'
+      - /include/sigc++-2.0
+      - /lib/pkgconfig
+      - /lib/sigc++-2.0
+
+  - name: glibmm
+    sources:
+      - sha256: 6e5fe03bdf1e220eeffd543e017fd2fb15bcec9235f0ffd50674aff9362a85f0
+        type: archive
+        url: http://ftp.gnome.org/pub/GNOME/sources/glibmm/2.58/glibmm-2.58.1.tar.xz
+    config-opts:
+      - --disable-documentation
+    cleanup:
+      - '*.la'
+      - /include/glibmm-2.4
+      - /include/giomm-2.4
+      - /lib/glibmm-2.4
+      - /lib/giomm-2.4
+      - /lib/libglibmm_generate_extra_defs*
+      - /lib/pkgconfig
+
+  - name: cairomm
+    sources:
+      - sha256: a54ada8394a86182525c0762e6f50db6b9212a2109280d13ec6a0b29bfd1afe6
+        type: archive
+        url: http://ftp.gnome.org/pub/GNOME/sources/cairomm/1.12/cairomm-1.12.0.tar.xz
+    config-opts:
+      - --disable-documentation
+    cleanup:
+      - '*.la'
+      - /include/cairomm-1.0
+      - /lib/cairomm-1.0
+      - /lib/pkgconfig
+
+  - name: pangomm
+    sources:
+      - sha256: ca6da067ff93a6445780c0b4b226eb84f484ab104b8391fb744a45cbc7edbf56
+        type: archive
+        url: http://ftp.gnome.org/pub/GNOME/sources/pangomm/2.42/pangomm-2.42.0.tar.xz
+    config-opts:
+      - --disable-documentation
+    cleanup:
+      - '*.la'
+      - /include/pangomm-1.4
+      - /lib/pangomm-1.4
+      - /lib/pkgconfig
+
+  - name: atkmm
+    sources:
+    - sha256: 4c4cfc917fd42d3879ce997b463428d6982affa0fb660cafcc0bc2d9afcedd3a
+      type: archive
+      url: http://ftp.gnome.org/pub/GNOME/sources/atkmm/2.28/atkmm-2.28.0.tar.xz
+    config-opts:
+      - --disable-documentation
+    cleanup:
+      - '*.la'
+      - /include/atkmm-1.6
+      - /lib/atkmm-1.6
+      - /lib/pkgconfig

--- a/org.gnome.Gnote.json
+++ b/org.gnome.Gnote.json
@@ -15,103 +15,11 @@
         "--talk-name=ca.desrt.dconf", "--env=DCONF_USER_CONFIG_DIR=.config/dconf"
     ],
     "cleanup": [
-        "*.a",
         "*.la",
-        "/include",
-        "/lib/atkmm-1.6",
-        "/lib/cairomm-1.0",
-        "/lib/gdkmm-3.0",
-        "/lib/giomm-2.4",
-        "/lib/glibmm-2.4",
-        "/lib/gtkmm-3.0",
-        "/lib/pangomm-1.4",
-        "/lib/pkgconfig",
-        "/lib/sigc++-2.0",
-        "/man",
-        "/share/aclocal",
-        "/share/gtk-doc",
-        "/share/man",
-        "/share/pkgconfig"
+        "/share/man"
     ],
     "modules": [
-        {
-            "name": "sigc++",
-            "sources": [
-                {
-                    "type": "archive",
-                    "url": "http://ftp.gnome.org/pub/GNOME/sources/libsigc++/2.10/libsigc++-2.10.0.tar.xz",
-                    "sha256": "f843d6346260bfcb4426259e314512b99e296e8ca241d771d21ac64f28298d81"
-                }
-            ],
-            "config-opts": [
-                "--disable-documentation"
-            ]
-        },
-        {
-            "name": "glibmm",
-            "sources": [
-                {
-                    "type": "archive",
-                    "url": "http://ftp.gnome.org/pub/GNOME/sources/glibmm/2.56/glibmm-2.56.0.tar.xz",
-                    "sha256": "6e74fcba0d245451c58fc8a196e9d103789bc510e1eee1a9b1e816c5209e79a9"
-                }
-            ],
-            "config-opts": [
-                "--disable-documentation"
-            ]
-        },
-        {
-            "name": "cairomm",
-            "sources": [
-                {
-                    "type": "archive",
-                    "url": "http://ftp.gnome.org/pub/GNOME/sources/cairomm/1.12/cairomm-1.12.0.tar.xz",
-                    "sha256": "a54ada8394a86182525c0762e6f50db6b9212a2109280d13ec6a0b29bfd1afe6"
-                }
-            ],
-            "config-opts": [
-                "--disable-documentation"
-            ]
-        },
-        {
-            "name": "pangomm",
-            "sources": [
-                {
-                    "type": "archive",
-                    "url": "http://ftp.gnome.org/pub/GNOME/sources/pangomm/2.40/pangomm-2.40.1.tar.xz",
-                    "sha256": "9762ee2a2d5781be6797448d4dd2383ce14907159b30bc12bf6b08e7227be3af"
-                }
-            ],
-            "config-opts": [
-                "--disable-documentation"
-            ]
-        },
-        {
-            "name": "atkmm",
-            "sources": [
-                {
-                    "type": "archive",
-                    "url": "http://ftp.gnome.org/pub/GNOME/sources/atkmm/2.24/atkmm-2.24.2.tar.xz",
-                    "sha256": "ff95385759e2af23828d4056356f25376cfabc41e690ac1df055371537e458bd"
-                }
-            ],
-            "config-opts": [
-                "--disable-documentation"
-            ]
-        },
-        {
-            "name": "gtkmm",
-            "sources": [
-                {
-                    "type": "archive",
-                    "url": "http://ftp.gnome.org/pub/GNOME/sources/gtkmm/3.22/gtkmm-3.22.2.tar.xz",
-                    "sha256": "91afd98a31519536f5f397c2d79696e3d53143b80b75778521ca7b48cb280090"
-                }
-            ],
-            "config-opts": [
-                "--disable-documentation"
-            ]
-        },
+        "gtkmm.yaml",
         {
             "name": "gnote",
             "sources": [

--- a/org.gnome.Gnote.json
+++ b/org.gnome.Gnote.json
@@ -27,6 +27,17 @@
                     "type": "archive",
                     "url": "https://ftp.gnome.org/pub/GNOME/sources/gnote/3.32/gnote-3.32.1.tar.xz",
                     "sha256": "b8c35188ab45409e3dbb153ac27ecb1029a344dcefff49d3cac4d9fa4c243366"
+                },
+                {
+                    "type": "patch",
+                    "paths": [
+                        "Add-OARS-and-update-appdata.patch",
+                        "appdata-replace-updatecontact-with-update_contact.patch",
+                        "appdata-simplify-content_rating.patch",
+                        "appdata-add-release-for-3.32.0.patch",
+                        "appdata-specify-translation.patch",
+                        "appdata-add-release-for-3.32.1.patch"
+                    ]
                 }
             ],
             "post-install": [

--- a/org.gnome.Gnote.json
+++ b/org.gnome.Gnote.json
@@ -1,7 +1,7 @@
 {
     "app-id": "org.gnome.Gnote",
     "runtime": "org.gnome.Platform",
-    "runtime-version": "3.30",
+    "runtime-version": "3.32",
     "sdk": "org.gnome.Sdk",
     "command": "gnote",
     "rename-appdata-file": "gnote.appdata.xml",
@@ -24,9 +24,9 @@
             "name": "gnote",
             "sources": [
                 {
-                "type": "archive",
-                "url": "http://ftp.acc.umu.se/pub/GNOME/sources/gnote/3.30/gnote-3.30.0.tar.xz",
-                "sha256": "29832f9e53662eab18036e839a41870048c6de947c1d9e00844edfa3ae0464d3"
+                    "type": "archive",
+                    "url": "https://ftp.gnome.org/pub/GNOME/sources/gnote/3.32/gnote-3.32.1.tar.xz",
+                    "sha256": "b8c35188ab45409e3dbb153ac27ecb1029a344dcefff49d3cac4d9fa4c243366"
                 }
             ],
             "post-install": [


### PR DESCRIPTION
~~This also updates the gtkmm, etc. dependencies by pulling them in from shared-modules, which depends on my PR at https://github.com/flathub/shared-modules/pull/54.~~

TODO:

- [x] Update to Gnote 3.32.1, released since I originally opened this PR
- [x] Inline gtkmm etc. updates since the PR above was not merged
- [x] Backport OARS data from upstream appdata file [MR](https://gitlab.gnome.org/GNOME/gnote/merge_requests/1)
- [x] Improve appdata (including `<releases>`)
- [x] [Submit improved appdata upstream](https://gitlab.gnome.org/GNOME/gnote/merge_requests/4)
