### PR TITLE
Issue #3 - separate help package with locale subset

### DIFF
--- a/org.gnome.Gnote.json
+++ b/org.gnome.Gnote.json
@@ -13,6 +13,13 @@
         "--socket=wayland",
         "--metadata=X-DConf=migrate-path=/org/gnome/gnote/"
     ],
+    "add-extensions": {
+        "org.gnome.Gnote.Help": {
+            "directory": "share/help",
+            "bundle": true,
+            "locale-subset": true
+        }
+    },
     "cleanup": [
         "*.la",
         "/share/man"


### PR DESCRIPTION
This split out help into a separate package that while download a subset depending on configured languages.

(Closes #3) 

However:
1 `C` isn't a valid locale, so I'm not sure it will use that version of help for even `en`.
2 If the language doesn't exist, flatpak doesn't download any.

All in all _this might be a regression_ compared to the current situation.

You can still manually install org.gnome.Gnote.Help to get the whole content.