### PR TITLE
Update to version 40.0, including runtime and dependencies

### DIFF
--- a/appdata.patch
+++ b/appdata.patch
@@ -1,0 +1,28 @@
+--- Temp/data/appdata/org.gnome.gnote.appdata.xml.in	2021-03-29 12:18:45.911996826 +1100
++++ Temp/org.gnome.gnote.appdata.xml.in	2021-03-29 12:21:45.942576650 +1100
+@@ -28,14 +28,14 @@
+       <li>Translation updates</li>
+     </ul>
+   </release>
+-  <release version="40.rc" date="2021-03-13">
++  <release version="40~rc" date="2021-03-13">
+     <ul>
+       <li>Use reverse-domain convention for naming desktop and search provider files</li>
+       <li>Refactor D-Bus support to reuse the connection established by GtkApplication</li>
+       <li>Update AppData file format</li>
+     </ul>
+   </release>
+-  <release version="40.beta" date="2021-02-21">
++  <release version="40~beta" date="2021-02-21">
+     <ul>
+       <li>Add accelerator Ctrl+D for insert timestamp</li>
+       <li>WebDAV sync no longer uses wdfs</li>
+@@ -43,7 +43,7 @@
+       <li>Fix crash when synchronizing immediately after configuring</li>
+     </ul>
+   </release>
+-  <release version="40.alpha" date="2021-01-10">
++  <release version="40~alpha" date="2021-01-10">
+     <ul>
+       <li>Change shortcut for find first/next to Ctrl-G/Ctrl-Shitf-G</li>
+       <li>Change icons and remove labels from find next/previous</li>

--- a/desktop-add-X-Endless-LaunchMaximized-false.patch
+++ b/desktop-add-X-Endless-LaunchMaximized-false.patch
@@ -1,4 +1,3 @@
-From 16fffc6525be102c7b3bf20912ac5c2fc81dcf79 Mon Sep 17 00:00:00 2001
 From: Will Thompson <will@willthompson.co.uk>
 Date: Fri, 29 Nov 2019 20:40:14 +0000
 Subject: [PATCH] desktop: add X-Endless-LaunchMaximized=false
@@ -7,19 +6,11 @@ Endless OS launches applications maximized by default under certain
 conditions.
 
 Gnote looks ridiculous maximized. Let's not do this.
----
- data/gnote.desktop.in.in | 1 +
- 1 file changed, 1 insertion(+)
 
-diff --git a/data/gnote.desktop.in.in b/data/gnote.desktop.in.in
-index 16e6627e..09a4e01e 100644
---- a/data/gnote.desktop.in.in
-+++ b/data/gnote.desktop.in.in
-@@ -15,3 +15,4 @@ X-GNOME-Bugzilla-Bugzilla=GNOME
+--- Temp/data/org.gnome.gnote.desktop.in.in	2021-03-29 11:43:48.979429328 +1100
++++ Temp/org.gnome.gnote.desktop.in.in	2021-03-29 11:44:15.248495328 +1100
+@@ -15,3 +15,4 @@
  X-GNOME-Bugzilla-Product=gnote
  X-GNOME-Bugzilla-Component=main
  X-GNOME-Bugzilla-Version=@GNOTE_VERSION@
 +X-Endless-LaunchMaximized=false
--- 
-2.20.1
-

--- a/gtkmm.json
+++ b/gtkmm.json
@@ -2,9 +2,9 @@
     "name": "gtkmm",
     "sources": [
         {
-            "sha256": "60497c4f7f354c3bd2557485f0254f8b7b4cf4bebc9fee0be26a77744eacd435",
+            "sha256": "9beb71c3e90cfcfb790396b51e3f5e7169966751efd4f3ef9697114be3be6743",
             "type": "archive",
-            "url": "http://ftp.gnome.org/pub/GNOME/sources/gtkmm/3.24/gtkmm-3.24.3.tar.xz"
+            "url": "http://ftp.gnome.org/pub/GNOME/sources/gtkmm/3.24/gtkmm-3.24.4.tar.xz"
         }
     ],
     "buildsystem": "meson",
@@ -64,9 +64,9 @@
             "name": "glibmm",
             "sources": [
                 {
-                    "sha256": "508fc86e2c9141198aa16c225b16fd6b911917c0d3817602652844d0973ea386",
+                    "sha256": "9e1db7d43d2e2d4dfa2771354e21a69a6beec7c446b711619cf8c779e13a581e",
                     "type": "archive",
-                    "url": "http://ftp.gnome.org/pub/GNOME/sources/glibmm/2.64/glibmm-2.64.5.tar.xz"
+                    "url": "http://ftp.gnome.org/pub/GNOME/sources/glibmm/2.66/glibmm-2.66.0.tar.xz"
                 }
             ],
             "buildsystem": "meson",
@@ -107,9 +107,9 @@
             "name": "pangomm",
             "sources": [
                 {
-                    "sha256": "1b24c92624ae1275ccb57758175d35f7c39ad3342d8c0b4ba60f0d9849d2d08a",
+                    "sha256": "d3787d04d6198b606f3efa357b3b452a7140e2a7dee56f9f9ce516d7d5fcec1b",
                     "type": "archive",
-                    "url": "http://ftp.gnome.org/pub/GNOME/sources/pangomm/2.42/pangomm-2.42.2.tar.xz"
+                    "url": "http://ftp.gnome.org/pub/GNOME/sources/pangomm/2.46/pangomm-2.46.0.tar.xz"
                 }
             ],
             "buildsystem": "meson",

--- a/org.gnome.Gnote.json
+++ b/org.gnome.Gnote.json
@@ -1,11 +1,11 @@
 {
     "app-id": "org.gnome.Gnote",
     "runtime": "org.gnome.Platform",
-    "runtime-version": "3.38",
+    "runtime-version": "40",
     "sdk": "org.gnome.Sdk",
     "command": "gnote",
-    "rename-appdata-file": "gnote.appdata.xml",
-    "rename-desktop-file": "gnote.desktop",
+    "rename-appdata-file": "org.gnome.gnote.appdata.xml",
+    "rename-desktop-file": "org.gnome.gnote.desktop",
     "rename-icon": "gnote",
     "copy-icon": true,
     "finish-args": [
@@ -25,19 +25,19 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://ftp.gnome.org/pub/GNOME/sources/gnote/3.38/gnote-3.38.0.tar.xz",
-                    "sha256": "fd36351f5fc8b4bf2e3a53d7d39798e0a33f0fc77ff781809577a346b85acfc6"
+                    "url": "https://ftp.gnome.org/pub/GNOME/sources/gnote/40/gnote-40.0.tar.xz",
+                    "sha256": "e224caf8bb433dec9a2258ea2f8739afabde577210e7fb17596614569f7d0b3b"
                 },
                 {
                     "type": "patch",
                     "paths": [
-                        "desktop-add-X-Endless-LaunchMaximized-false.patch"
+                        "desktop-add-X-Endless-LaunchMaximized-false.patch",
+                        "appdata.patch"
                     ]
                 }
             ],
             "post-install": [
-                "mv /app/share/gnome-shell/search-providers/gnote-search-provider.ini /app/share/gnome-shell/search-providers/org.gnome.Gnote.ini",
-                "sed -i -e 's/DesktopId=gnote.desktop/DesktopId=org.gnome.Gnote.desktop/' /app/share/gnome-shell/search-providers/org.gnome.Gnote.ini"
+                "sed -i -e 's/DesktopId=gnote.desktop/DesktopId=org.gnome.Gnote.desktop/' /app/share/gnome-shell/search-providers/org.gnome.Gnote.search-provider.ini"
             ]
         }
     ]


### PR DESCRIPTION
Upstream renamed the appdata and desktop files, so those needed to be adjusted here (it doesn't quite match the app ID here, so we still need to rename them to fit). I also had to rework the Endless OS patch a bit since just changing the file names didn't work for some reason, it still does the same thing though.

Also, the AppStream validator got confused about the alpha/beta/rc naming scheme so I used ~ as a workaround (the GNOME Calculator flatpak does the same).

Finally, there was an update to intltool in the shared-modules repo so I updated the submodule as well.