### PR TITLE
Move help translations to .Locale extension

### DIFF
--- a/org.gnome.Gnote.json
+++ b/org.gnome.Gnote.json
@@ -35,6 +35,7 @@
                 }
             ],
             "post-install": [
+                "for help_locale_dir in /app/share/help/??*; do mv $help_locale_dir /app/share/locale/${help_locale_dir##*/}/help; ln -s /app/share/locale/${help_locale_dir##*/}/help $help_locale_dir; done",
                 "sed -i -e 's/DesktopId=gnote.desktop/DesktopId=org.gnome.Gnote.desktop/' /app/share/gnome-shell/search-providers/org.gnome.Gnote.search-provider.ini"
             ]
         }


### PR DESCRIPTION
Previously, the main Flatpak contained the untranslated help in
/app/share/help/C, plus all available help translations in
/app/share/help/$locale.

Move all bar the C translations into /app/share/locale/$locale/help, so
that the normal locale-subsetting behaviour kicks in and users only need
help in languages used on their system. The C help is left at
/app/share/help/C, and hence always installed.

Fixes #3