### PR TITLE
Add Flatpak External Data Checker config for app

### DIFF
--- a/org.gnome.Gnote.json
+++ b/org.gnome.Gnote.json
@@ -22,6 +22,10 @@
             "buildsystem": "meson",
             "sources": [
                 {
+                    "x-checker-data": {
+                        "type": "gnome",
+                        "name": "gnote"
+                    },
                     "type": "archive",
                     "url": "https://ftp.gnome.org/pub/GNOME/sources/gnote/41/gnote-41.1.tar.xz",
                     "sha256": "58db2cad13b44167a9efa1544103526c67e6efaa86dafb3a314ea142950e2162"

--- a/org.gnome.Gnote.json
+++ b/org.gnome.Gnote.json
@@ -27,8 +27,8 @@
                         "name": "gnote"
                     },
                     "type": "archive",
-                    "url": "https://ftp.gnome.org/pub/GNOME/sources/gnote/41/gnote-41.1.tar.xz",
-                    "sha256": "58db2cad13b44167a9efa1544103526c67e6efaa86dafb3a314ea142950e2162"
+                    "url": "https://download.gnome.org/sources/gnote/41/gnote-41.2.tar.xz",
+                    "sha256": "21b0ef43514e6b68a08ed8573130185be36dbb9fb463b426ebd9f18c5092423f"
                 },
                 {
                     "type": "patch",


### PR DESCRIPTION
There is a 41.2 release. I have tested that the checker will pick it up given this config.

`gtkmm.json` is hairier, as I previously discovered on https://github.com/flathub/org.pulseaudio.pavucontrol/pull/19.

