### PR TITLE
Update glibmm and gtkmm modules and GNOME 49

### DIFF
--- a/gtkmm.json
+++ b/gtkmm.json
@@ -3,8 +3,8 @@
     "sources": [
         {
             "type": "archive",
-            "url": "https://download.gnome.org/sources/gtkmm/4.18/gtkmm-4.18.0.tar.xz",
-            "sha256": "2ee31c15479fc4d8e958b03c8b5fbbc8e17bc122c2a2f544497b4e05619e33ec",
+            "url": "https://download.gnome.org/sources/gtkmm/4.20/gtkmm-4.20.0.tar.xz",
+            "sha256": "daad9bf9b70f90975f91781fc7a656c923a91374261f576c883cd3aebd59c833",
             "x-checker-data": {
                 "type": "gnome",
                 "name": "gtkmm",
@@ -63,8 +63,8 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://download.gnome.org/sources/glibmm/2.84/glibmm-2.84.0.tar.xz",
-                    "sha256": "56ee5f51c8acfc0afdf46959316e4c8554cb50ed2b6bc5ce389d979cbb642509",
+                    "url": "https://download.gnome.org/sources/glibmm/2.86/glibmm-2.86.0.tar.xz",
+                    "sha256": "39c0e9f6da046d679390774efdb9ad564436236736dc2f7825e614b2d4087826",
                     "x-checker-data": {
                         "type": "gnome",
                         "name": "glibmm",

--- a/org.gnome.Gnote.json
+++ b/org.gnome.Gnote.json
@@ -1,7 +1,7 @@
 {
     "app-id": "org.gnome.Gnote",
     "runtime": "org.gnome.Platform",
-    "runtime-version": "48",
+    "runtime-version": "49",
     "sdk": "org.gnome.Sdk",
     "command": "gnote",
     "finish-args": [


### PR DESCRIPTION
Update runtime to GNOME 49

glibmm: Update glibmm-2.84.0.tar.xz to 2.86.0
gtkmm: Update gtkmm-4.18.0.tar.xz to 4.20.0

Close #75
Close #76 